### PR TITLE
Fix bug opening multiple popups Android

### DIFF
--- a/src/Rg.Plugins.Popup.Droid/Impl/PopupPlatformDroid.cs
+++ b/src/Rg.Plugins.Popup.Droid/Impl/PopupPlatformDroid.cs
@@ -29,16 +29,15 @@ namespace Rg.Plugins.Popup.Droid.Impl
 
         public async Task AddAsync(PopupPage page)
         {
-            var decoreView = DecoreView;
-
-            page.Parent = XApplication.Current.MainPage;
-
-            var renderer = page.GetOrCreateRenderer();
-
-            decoreView.AddView(renderer.ViewGroup);
-            UpdateListeners(true);
-
-            await Task.Delay(5);
+           if (page.Parent==null)
+            {
+				var decoreView = DecoreView;
+				page.Parent = XApplication.Current.MainPage;
+				var renderer = page.GetOrCreateRenderer();
+				decoreView.AddView(renderer.ViewGroup);
+				UpdateListeners(true);
+				await Task.Delay(5);
+			}
         }
 
         public async Task RemoveAsync(PopupPage page)


### PR DESCRIPTION
if you press multiple times to open like this, Android throws an error:
```
var t = new ListViewPopPage();
new Button { Text="ListView", Command = new Command(async ()=>{  await Navigation.PushPopupAsync(t); }) },
       
```

**UNHANDLED EXCEPTION:**
`06-14 13:09:36.179 I/MonoDroid(12118): Java.Lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
06-14 13:09:36.179 I/MonoDroid(12118):   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <3fd174ff54b146228c505f23cf75ce71>:0 `
