### PR TITLE
allow IPopupNavigation to be mocked or extended

### DIFF
--- a/src/Rg.Plugins.Popup/Services/PopupNavigation.cs
+++ b/src/Rg.Plugins.Popup/Services/PopupNavigation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using Rg.Plugins.Popup.Contracts;
 using Rg.Plugins.Popup.Pages;
@@ -30,6 +31,9 @@ namespace Rg.Plugins.Popup.Services
                 return _popupNavigation;
             }
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetInstance(IPopupNavigation instance) => _popupNavigation = instance;
 
         [Obsolete(DepractedMethodsText)]
         public static IReadOnlyList<PopupPage> PopupStack => Instance.PopupStack;


### PR DESCRIPTION
This addresses issue #256 by allowing a Mock instance to be set for Unit Tests. It also helps to make the library more extensible by allowing other platforms to be more easily added #226 #272 