### PR TITLE
Return exception to caller while executing action in main thread.

### DIFF
--- a/src/Rg.Plugins.Popup/Services/PopupNavigationImpl.cs
+++ b/src/Rg.Plugins.Popup/Services/PopupNavigationImpl.cs
@@ -160,9 +160,15 @@ namespace Rg.Plugins.Popup.Services
 
             Device.BeginInvokeOnMainThread(async () =>
             {
-                await action.Invoke();
-
-                tcs.SetResult(true);
+                try
+                {
+                    await action.Invoke();
+                    tcs.SetResult(true);
+                }
+                catch (Exception e)
+                {
+                    tcs.SetException(e);
+                }
             });
 
             return tcs.Task;


### PR DESCRIPTION
All methods on IPopupNavigation are being executed on main thread using Device.BeginInvokeOnMainThread, but if any exception gets thrown while executing passed action, the app gets crashed. My PR sends back that exception to caller. This approach is being copied from [Microsoft docs](https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/implementing-the-task-based-asynchronous-pattern#generating-tap-methods-manually) (See code snippets)
Thanks in advance (-: