### PR TITLE
Resolve NullReferenceException on Android

### DIFF
--- a/src/Rg.Plugins.Popup.Droid/Impl/PopupPlatformDroid.cs
+++ b/src/Rg.Plugins.Popup.Droid/Impl/PopupPlatformDroid.cs
@@ -54,7 +54,7 @@ namespace Rg.Plugins.Popup.Droid.Impl
                 var element = renderer.Element;
 
                 DecoreView.RemoveView(renderer.View);
-                renderer.Dispose();
+                renderer?.Dispose();
 
                 if(element != null)
                     element.Parent = null;


### PR DESCRIPTION
Resolves this: 

```
[mono] Unhandled Exception:
[mono] System.NullReferenceException: Object reference not set to an instance of an object.
[mono]   at Xamarin.Forms.Platform.Android.VisualElementRenderer`1[TElement].Dispose (System.Boolean disposing) [0x000a6] in D:\a\1\s\Xamarin.Forms.Platform.Android\VisualElementRenderer.cs:297 
[mono]   at Xamarin.Forms.Platform.Android.Platform+DefaultRenderer.Dispose (System.Boolean disposing) [0x0000a] in D:\a\1\s\Xamarin.Forms.Platform.Android\Platform.cs:1255 
[mono]   at Java.Lang.Object.Dispose () [0x00000] in <ea97b6d670fe4c1ba9dadb89b2fa0103>:0 
[mono]   at Xamarin.Forms.Platform.Android.VisualElementRenderer`1[TElement].Dispose (System.Boolean disposing) [0x000a6] in D:\a\1\s\Xamarin.Forms.Platform.Android\VisualElementRenderer.cs:297 
[mono]   at Xamarin.Forms.Platform.Android.Platform+DefaultRenderer.Dispose (System.Boolean disposing) [0x0000a] in D:\a\1\s\Xamarin.Forms.Platform.Android\Platform.cs:1255 
[mono]   at Java.Lang.Object.Dispose () [0x00000] in <ea97b6d670fe4c1ba9dadb89b2fa0103>:0 
[mono]   at Xamarin.Forms.Platform.Android.ScrollViewContainer.Dispose (System.Boolean disposing) [0x00013] in D:\a\1\s\Xamarin.Forms.Platform.Android\Renderers\ScrollViewContainer.cs:52 
[mono]   at Java.Lang.Object.Dispose () [0x00000] in <ea97b6d670fe4c1ba9dadb89b2fa0103>:0 
[mono]   at Xamarin.Forms.Platform.Android.ScrollViewRenderer.Dispose (System.Boolean disposing) [0x00038] in D:\a\1\s\Xamarin.Forms.Platform.Android\Renderers\ScrollViewRenderer.cs:214 
[mono]   at Java.Lang.Object.Dispose () [0x00000] in <ea97b6d670fe4c1ba9dadb89b2fa0103>:0 
[mono]   at Xamarin.Forms.Platform.Android.VisualElementRenderer`1[TElement].Dispose (System.Boolean disposing) [0x000a6] in D:\a\1\s\Xamarin.Forms.Platform.Android\VisualElementRenderer.cs:297 
[mono]   at Xamarin.Forms.Platform.Android.Platform+DefaultRenderer.Dispose (System.Boolean disposing) [0x0000a] in D:\a\1\s\Xamarin.Forms.Platform.Android\Platform.cs:1255 
[mono]   at Java.Lang.Object.Dispose () [0x00000] in <ea97b6d670fe4c1ba9dadb89b2fa0103>:0 
[mono]   at Xamarin.Forms.Platform.Android.VisualElementRenderer`1[TElement].Dispose (System.Boolean disposing) [0x000a6] in D:\a\1\s\Xamarin.Forms.Platform.Android\VisualElementRenderer.cs:297 
[mono]   at Xamarin.Forms.Platform.Android.PageRenderer.Dispose (System.Boolean disposing) [0x00011] in D:\a\1\s\Xamarin.Forms.Platform.Android\Renderers\PageRenderer.cs:34 
[mono]   at Rg.Plugins.Popup.Droid.Renderers.PopupPageRenderer.Dispose (System.Boolean disposing) [0x00037] in C:\projects\rg-plugins-popup\src\Rg.Plugins.Popup.Droid\Renderers\PopupPageRenderer.cs:53 
[mono]   at Java.Lang.Object.Dispose () [0x00000] in <ea97b6d670fe4c1ba9dadb89b2fa0103>:0 
[mono]   at Rg.Plugins.Popup.Droid.Impl.PopupPlatformDroid.RemoveAsync (Rg.Plugins.Popup.Pages.PopupPage page) [0x00022] in C:\projects\rg-plugins-popup\src\Rg.Plugins.Popup.Droid\Impl\PopupPlatformDroid.cs:57 
[mono]   at Rg.Plugins.Popup.Services.PopupNavigationImpl+<RemoveAsync>d__12.MoveNext () [0x00011] in C:\projects\rg-plugins-popup\src\Rg.Plugins.Popup\Services\PopupNavigationImpl.cs:134 
```

Could you release dev nugets for this?