### PR TITLE
Change BackgroundImage to BackgroundImageSource

### DIFF
--- a/src/Rg.Plugins.Popup/Animations/Base/FadeBackgroundAnimation.cs
+++ b/src/Rg.Plugins.Popup/Animations/Base/FadeBackgroundAnimation.cs
@@ -12,7 +12,7 @@ namespace Rg.Plugins.Popup.Animations.Base
 
         public override void Preparing(View content, PopupPage page)
         {
-            if (HasBackgroundAnimation && page.BackgroundImage == null)
+            if (HasBackgroundAnimation && page.BackgroundImageSource == null)
             {
                 _backgroundColor = page.BackgroundColor;
                 page.BackgroundColor = GetColor(0);
@@ -21,7 +21,7 @@ namespace Rg.Plugins.Popup.Animations.Base
 
         public override void Disposing(View content, PopupPage page)
         {
-            if (HasBackgroundAnimation && page.BackgroundImage == null)
+            if (HasBackgroundAnimation && page.BackgroundImageSource == null)
             {
                 page.BackgroundColor = _backgroundColor;
             }
@@ -29,7 +29,7 @@ namespace Rg.Plugins.Popup.Animations.Base
 
         public override Task Appearing(View content, PopupPage page)
         {
-            if (HasBackgroundAnimation && page.BackgroundImage == null)
+            if (HasBackgroundAnimation && page.BackgroundImageSource == null)
             {
                 TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
                 page.Animate("backgroundFade", d =>
@@ -48,7 +48,7 @@ namespace Rg.Plugins.Popup.Animations.Base
 
         public override Task Disappearing(View content, PopupPage page)
         {
-            if (HasBackgroundAnimation && page.BackgroundImage == null)
+            if (HasBackgroundAnimation && page.BackgroundImageSource == null)
             {
                 TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
 


### PR DESCRIPTION
Please change the refrence of **BackgroundImage** prop to the new one **BackgroundImageSource**
Since Xamarin Forms >= 4.0 **BackgroundImage is Obsolete** and IOS Building throws an error when wanting to Publish the App pointing to this file and BackgroundImage property as the error

I like your plugin very much, it's great, and I'm using it in my Xamarin projects but now I can't use it for IOS, please help

Best regards
Bogdan Babici