### PR TITLE
App unresponsive after closing any popup. See #477

### DIFF
--- a/src/Rg.Plugins.Popup.IOS/Impl/PopupPlatformIos.cs
+++ b/src/Rg.Plugins.Popup.IOS/Impl/PopupPlatformIos.cs
@@ -47,7 +47,7 @@ namespace Rg.Plugins.Popup.IOS.Impl
             var renderer = page.GetOrCreateRenderer();
 
             var window = new PopupWindow();
-
+            window.OriginalKeyWindow = UIApplication.SharedApplication.KeyWindow;
             if (IsiOS13OrNewer)
                 _windows.Add(window);
 
@@ -71,7 +71,7 @@ namespace Rg.Plugins.Popup.IOS.Impl
             await Task.Delay(50);
 
             page.DescendantRemoved -= HandleChildRemoved;
-
+            var popup = (PopupWindow)viewController.View.Window;
             if (renderer != null && viewController != null && !viewController.IsBeingDismissed)
             {
                 var window = viewController.View.Window;
@@ -87,10 +87,10 @@ namespace Rg.Plugins.Popup.IOS.Impl
 
                 window.Dispose();
                 window = null;
-
-                if (UIApplication.SharedApplication.KeyWindow.WindowLevel == -1)
-                    UIApplication.SharedApplication.KeyWindow.WindowLevel = UIWindowLevel.Normal;
             }
+
+            popup.OriginalKeyWindow.WindowLevel = UIWindowLevel.Normal;
+            popup.OriginalKeyWindow.MakeKeyAndVisible(); 
         }
 
         void DisposeModelAndChildrenRenderers(VisualElement view)

--- a/src/Rg.Plugins.Popup.IOS/Platform/PopupWindow.cs
+++ b/src/Rg.Plugins.Popup.IOS/Platform/PopupWindow.cs
@@ -10,6 +10,8 @@ namespace Rg.Plugins.Popup.IOS.Platform
     [Register("RgPopupWindow")]
     internal class PopupWindow : UIWindow
     {
+        //Save the reference to uiwindow that was the original key window before the popupwindow got presented
+        public UIWindow OriginalKeyWindow { get; set; }
         public PopupWindow(IntPtr handle):base(handle)
         {
             // Fix #307


### PR DESCRIPTION
So this is how I got it working in my app, the problem was that the keywindow in the remove method that gets restored from -1 to normal is for some reason not the same key window at the time the window was added. So what I had to do is store that reference, so it's the same window the one that gets restored it's windowlevel at the time of the removal. What do you think?