### PR TITLE
PreferredStatusBarStyle is not settable when popups are presented

### DIFF
--- a/src/Demo/Demo.iOS/Demo.iOS.csproj
+++ b/src/Demo/Demo.iOS/Demo.iOS.csproj
@@ -108,6 +108,7 @@
     <ITunesArtwork Include="iTunesArtwork" />
     <ITunesArtwork Include="iTunesArtwork@2x" />
     <None Include="packages.config" />
+    <Compile Include="LoginPopupPageRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\Default-568h%402x.png" />

--- a/src/Demo/Demo.iOS/Info.plist
+++ b/src/Demo/Demo.iOS/Info.plist
@@ -46,6 +46,8 @@
 		<string>Icon-Small@2x</string>
 		<string>Icon-Small@3x</string>
 	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 </dict>

--- a/src/Demo/Demo.iOS/LoginPopupPageRenderer.cs
+++ b/src/Demo/Demo.iOS/LoginPopupPageRenderer.cs
@@ -1,0 +1,26 @@
+﻿using Demo.iOS;
+using Demo.Pages;
+using Rg.Plugins.Popup.IOS.Renderers;
+using UIKit;
+using Xamarin.Forms;
+
+[assembly: ExportRenderer(typeof(LoginPopupPage), typeof(LoginPopupPageRenderer))]
+namespace Demo.iOS
+{
+    public class LoginPopupPageRenderer : PopupPageRenderer
+    { 
+        public override bool PrefersStatusBarHidden()
+        {
+            return false; 
+        }
+
+        public override UIStatusBarStyle PreferredStatusBarStyle()
+        {
+            if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0) && TraitCollection.UserInterfaceStyle == UIUserInterfaceStyle.Dark)
+            {
+                return UIStatusBarStyle.DarkContent;
+            }
+            return UIStatusBarStyle.LightContent; 
+        }
+    }
+}

--- a/src/Rg.Plugins.Popup.IOS/Platform/PopupPlatformRenderer.cs
+++ b/src/Rg.Plugins.Popup.IOS/Platform/PopupPlatformRenderer.cs
@@ -56,6 +56,21 @@ namespace Rg.Plugins.Popup.IOS.Platform
             return _renderer.ViewController;
         }
 
+        public override bool PrefersStatusBarHidden()
+        {
+            return _renderer.ViewController.PrefersStatusBarHidden();
+        }
+
+        public override UIViewController ChildViewControllerForStatusBarStyle()
+        {
+            return _renderer.ViewController;
+        }
+
+        public override UIStatusBarStyle PreferredStatusBarStyle()
+        {
+            return _renderer.ViewController.PreferredStatusBarStyle();
+        }
+
         public override bool ShouldAutorotate()
         {
             if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))


### PR DESCRIPTION
Solves #397 

* Forwards `PreferredStatusBarStyle` and `PrefersStatusBarHidden` from `PopupPlatformRenderer` to the `PopupPageRenderer` allowing client customisation. 
* Updates `Info.plist` in Demo.iOS setting UIViewControllerBasedStatusBarAppearance = YES (the status bar will get the style based on PreferredStatusBarStyle) 
* Adds LoginPageRenderer in Demo.iOS to illustrate change in status bar color

![custom – 1](https://user-images.githubusercontent.com/26183235/76145302-0ba35780-6091-11ea-8a77-a248a3898c44.png)

