### PR TITLE
target android 9 and 10 together #514

### DIFF
--- a/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
+++ b/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
-    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid9.0;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.17763;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetsToBuild)' != 'All' ">
-    <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Android' ">netstandard2.0;monoandroid10.0;</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Android' ">netstandard2.0;monoandroid10.0;monoandroid9.0;</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Uap' ">netstandard2.0;uap10.0.17763</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'iOS' ">netstandard2.0;xamarin.ios10</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Apple' ">netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10</TargetFrameworks>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
An application developer has to use Android 10 SDK

### :new: What is the new behavior (if this is a feature change)?
An application developer can use either android 9 or 10 sdks. It's a matter of choice between AndroidX and legacy Android support libraries too. See #514
Note that daily downloads of legacy android support libraries at the moment are 10X in comparison with AndroidX nugget packages. (5300 vs 300)

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
N/A

### :memo: Links to relevant issues/docs
#514

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guidelines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
