### PR TITLE
UAP Min Target 10.0.16299

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 - [x] Android
 - [x] iOS
-- [x] UWP (Min Target: 10.0.17763)
+- [x] UWP (Min Target: 10.0.16299)
 - [x] Tizen
 - [x] WPF
 - [x] MacOS

--- a/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
+++ b/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
     <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid9.0;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.17763;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetsToBuild)' != 'All' ">
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Android' ">netstandard2.0;monoandroid10.0;monoandroid9.0;</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Uap' ">netstandard2.0;uap10.0.17763</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Uap' ">netstandard2.0;uap10.0.16299</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'iOS' ">netstandard2.0;xamarin.ios10</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Apple' ">netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10</TargetFrameworks>
   </PropertyGroup>

--- a/Samples/Demo.UWP/Demo.UWP.csproj
+++ b/Samples/Demo.UWP/Demo.UWP.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>ru-RU</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Samples/Directory.build.targets
+++ b/Samples/Directory.build.targets
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <DefineConstants>$(DefineConstants);NETFX_CORE;XAML;WINDOWS;WINDOWS_UWP;UWP</DefineConstants>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('xamarin.ios'))">
     <DefineConstants>$(DefineConstants);MONO;UIKIT;COCOA;APPLE;IOS</DefineConstants>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Supports a Min Target of 10.0.16299 in UAP (Like Xamarin Forms)

### :arrow_heading_down: What is the current behavior?
Supports a Min Target of 10.0.16299 in UAP (Like Xamarin Forms)

### :new: What is the new behavior (if this is a feature change)?
Supports Min Target of 10.0.17763 in UAP causes problems for upgrades of this Library,
Because 10.0.16299 is still supported by Microsoft.

### :boom: Does this PR introduce a breaking change?
No (Older Version supported)

### :bug: Recommendations for testing
Execute Demo UWP Project (Has now Min Version of 10.0.16299 and Target Version of  10.0.17763)

### :memo: Links to relevant issues/docs
Dependencies are UAP 10.0.16299 for .Net Standard compatibility
https://www.nuget.org/packages/Xamarin.Forms/4.5.0.657

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated 
- [x] Rebased onto current develop
