### PR TITLE
[Android] Remove correct page on back button pressed

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Android/Popup.cs
+++ b/Rg.Plugins.Popup/Platforms/Android/Popup.cs
@@ -41,7 +41,7 @@ namespace Rg.Plugins.Popup
                 {
                     Device.BeginInvokeOnMainThread(async () =>
                     {
-                        await popupNavigationInstance.PopAsync();
+                        await popupNavigationInstance.RemovePageAsync(lastPage);
                     });
                 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR fixes race condition bug in android

### :arrow_heading_down: What is the current behavior?
Raise popup nr.1
Press back
Raise another popup nr.2 between entering in OnBackButtonPressed method in popup nr.1 and returning false from it
Popup nr.2 will be popped instead of popup nr.1 even though we called OnBackButtonPressed on nr.1

### :new: What is the new behavior (if this is a feature change)?
Popup nr.1 will correctly be removed and nr.2 will stay visible

### :boom: Does this PR introduce a breaking change?
Not sure

### :bug: Recommendations for testing
Described in current behaviour


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
