### PR TITLE
fix crash on uwp. support older uwp versions.

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
@@ -97,9 +97,10 @@ namespace Rg.Plugins.Popup.Windows.Renderers
             }
         }
 
-        private async void UpdateElementSize()
+        private void UpdateElementSize()
         {
-            await Task.Delay(50);
+            //fix crashes with CurrentElement being null.
+            //await Task.Delay(50);
 
             var windowBound = Window.Current.Bounds;
             var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
@@ -117,10 +118,14 @@ namespace Rg.Plugins.Popup.Windows.Renderers
 
             var systemPadding = new Xamarin.Forms.Thickness(left, top, right, bottom);
 
-            CurrentElement.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
-            CurrentElement.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
-            CurrentElement.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
-            CurrentElement.ForceLayout();
+            var element = CurrentElement;
+            if (element != null)
+            {
+                element.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
+                element.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
+                element.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
+                element.ForceLayout();
+            }
         }
     }
 }

--- a/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
+++ b/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
@@ -2,11 +2,12 @@
   <PropertyGroup Condition=" '$(TargetsToBuild)' == 'All' ">
     <TargetFrameworks>netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10;xamarin.watchos10;monoandroid9.0;monoandroid10.0;tizen40;netcoreapp3.1;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.17763;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetsToBuild)' != 'All' ">
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Android' ">netstandard2.0;monoandroid10.0;monoandroid9.0;</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Uap' ">netstandard2.0;uap10.0.17763</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Uap' ">netstandard2.0;uap10.0.17763;uap10.0.16299</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'iOS' ">netstandard2.0;xamarin.ios10</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TargetsToBuild)' == 'Apple' ">netstandard2.0;xamarin.ios10;xamarin.mac20;xamarin.tvos10</TargetFrameworks>
   </PropertyGroup>

--- a/Samples/Demo.UWP/Demo.UWP.csproj
+++ b/Samples/Demo.UWP/Demo.UWP.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>Demo.UWP</AssemblyName>
     <DefaultLanguage>ru-RU</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -143,19 +143,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>1.0.0</Version>
+      <Version>2.14.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.PersistenceChannel">
-      <Version>1.0.0</Version>
+      <Version>1.2.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsApps">
-      <Version>1.0.0</Version>
+      <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.9</Version>
+      <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.5.0.530</Version>
+      <Version>4.7.0.1239</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
support older uwp versions (down to windows 10 build 16299, like Xamarin.Forms).
fix crash on uwp mostly caused by the 50ms await and not testing the element property to null.

### :arrow_heading_down: What is the current behavior?
supports only windows 10 1809+
crash on close in the worst conditions (fast windows machines mostly)

### :new: What is the new behavior (if this is a feature change)?
no feature change

### :boom: Does this PR introduce a breaking change?
no breaking change

### :bug: Recommendations for testing
the uwp sample was updated to use windows 10 build 16299

### :memo: Links to relevant issues/docs
none

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [-] Relevant documentation was updated
- [X] Rebased onto current develop
