### PR TITLE
Fix for error if page is closed before its actually displayed

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
@@ -116,11 +116,13 @@ namespace Rg.Plugins.Popup.Windows.Renderers
             right = Math.Max(0, right);
 
             var systemPadding = new Xamarin.Forms.Thickness(left, top, right, bottom);
-
-            CurrentElement.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
-            CurrentElement.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
-            CurrentElement.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
-            CurrentElement.ForceLayout();
+            if (CurrentElement != null)
+            {
+                CurrentElement.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
+                CurrentElement.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
+                CurrentElement.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
+                CurrentElement.ForceLayout();
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for this exception

Exception: System.NullReferenceException: Object reference not set to an instance of an object.     at Rg.Plugins.Popup.Windows.Renderers.PopupPageRenderer.UpdateElementSize()     at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<>c.<ThrowAsync>b__7_0(Object state)     at System.Threading.WinRTSynchronizationContextBase.Invoker.InvokeCore()