### PR TITLE
Update PopupPlatformMacOS.cs

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Mac/Impl/PopupPlatformMacOS.cs
+++ b/Rg.Plugins.Popup/Platforms/Mac/Impl/PopupPlatformMacOS.cs
@@ -37,7 +37,8 @@ namespace Rg.Plugins.Popup.MacOS.Impl
 
             var renderer = page.GetOrCreateRenderer();
 
-            NSApplication.SharedApplication.MainWindow.ContentView.AddSubview(renderer.NativeView);
+            var forcedMainWindow = NSApplication.SharedApplication.MainWindow ?? Application.Current.MainPage.GetOrCreateRenderer().NativeView.Window;
+            forcedMainWindow.ContentView.AddSubview(renderer.NativeView);
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION




### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix


### :arrow_heading_down: What is the current behavior?

Currently, in a situation where 
-> A popup is created
-> Thread.Delay is called and awaited
-> User switches to a different program, putting the program using rg.popups in the backround

There will be an error is MainWindow becomes null

### :new: What is the new behaviour (if this is a feature change)?
New behaviour is before it attempts to reach MainWindow, we do a null check,
If main window is null, it attempts to get the window that contains the Root navigation page (from Xamarin Forms)

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Follow testing in #558 

I am unsure of the downsides or pitfalls concerning using `Application.Current.MainPage.GetOrCreateRenderer().NativeView.Window;`
However it seems to avoid the issue where NSApplication.SharedApplication.MainWindow is null in particular scenarios


### :memo: Links to relevant issues/docs

#558 
### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
