### PR TITLE
Fixes #578

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
@@ -101,6 +101,8 @@ namespace Rg.Plugins.Popup.Windows.Renderers
         {
             if (CurrentElement != null)
             {
+                var capturedElement = CurrentElement;
+
                 var windowBound = Window.Current.Bounds;
                 var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
                 var keyboardHeight = _keyboardBounds != Rect.Empty ? _keyboardBounds.Height : 0;
@@ -112,13 +114,13 @@ namespace Rg.Plugins.Popup.Windows.Renderers
 
                 var systemPadding = new Xamarin.Forms.Thickness(left, top, right, bottom);
 
-                CurrentElement.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
-                CurrentElement.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
+                capturedElement.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
+                capturedElement.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
                 //if its not invoked on MainThread when the popup is showed it will be blank until the user manually resizes of owner window
                 Device.BeginInvokeOnMainThread(() =>
                 {
-                    CurrentElement.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
-                    CurrentElement.ForceLayout();
+                    capturedElement.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
+                    capturedElement.ForceLayout();
                 });
             }
         }

--- a/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
@@ -99,35 +99,26 @@ namespace Rg.Plugins.Popup.Windows.Renderers
 
         private void UpdateElementSize()
         {
-            //fix crashes with CurrentElement being null.
-            //await Task.Delay(50);
-
-            var windowBound = Window.Current.Bounds;
-            var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
-            var keyboardHeight = _keyboardBounds != Rect.Empty ? _keyboardBounds.Height : 0;
-
-            var top = visibleBounds.Top - windowBound.Top;
-            var bottom = windowBound.Bottom - visibleBounds.Bottom;
-            var left = visibleBounds.Left - windowBound.Left;
-            var right = windowBound.Right - visibleBounds.Right;
-
-            top = Math.Max(0, top);
-            bottom = Math.Max(0, bottom);
-            left = Math.Max(0, left);
-            right = Math.Max(0, right);
-
-            var systemPadding = new Xamarin.Forms.Thickness(left, top, right, bottom);
-
-            var element = CurrentElement;
-            if (element != null)
+            if (CurrentElement != null)
             {
-                element.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
-                element.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
+                var windowBound = Window.Current.Bounds;
+                var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
+                var keyboardHeight = _keyboardBounds != Rect.Empty ? _keyboardBounds.Height : 0;
+
+                var top = Math.Max(0, visibleBounds.Top - windowBound.Top);
+                var bottom = Math.Max(0, windowBound.Bottom - visibleBounds.Bottom);
+                var left = Math.Max(0, visibleBounds.Left - windowBound.Left);
+                var right = Math.Max(0, windowBound.Right - visibleBounds.Right);
+
+                var systemPadding = new Xamarin.Forms.Thickness(left, top, right, bottom);
+
+                CurrentElement.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
+                CurrentElement.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
                 //if its not invoked on MainThread when the popup is showed it will be blank until the user manually resizes of owner window
                 Device.BeginInvokeOnMainThread(() =>
                 {
-                    element.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
-                    element.ForceLayout();
+                    CurrentElement.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
+                    CurrentElement.ForceLayout();
                 });
             }
         }

--- a/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Uap/Renderers/PopupPageRenderer.cs
@@ -14,7 +14,7 @@ using Size = Windows.Foundation.Size;
 using Xamarin.Forms.Platform.UWP;
 using WinPopup = global::Windows.UI.Xaml.Controls.Primitives.Popup;
 
-[assembly:ExportRenderer(typeof(PopupPage), typeof(PopupPageRenderer))]
+[assembly: ExportRenderer(typeof(PopupPage), typeof(PopupPageRenderer))]
 namespace Rg.Plugins.Popup.Windows.Renderers
 {
     [Preserve(AllMembers = true)]
@@ -29,7 +29,7 @@ namespace Rg.Plugins.Popup.Windows.Renderers
         [Preserve]
         public PopupPageRenderer()
         {
-            
+
         }
 
         private void OnKeyboardHiding(InputPane sender, InputPaneVisibilityEventArgs args)
@@ -123,8 +123,12 @@ namespace Rg.Plugins.Popup.Windows.Renderers
             {
                 element.SetValue(PopupPage.SystemPaddingProperty, systemPadding);
                 element.SetValue(PopupPage.KeyboardOffsetProperty, keyboardHeight);
-                element.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
-                element.ForceLayout();
+                //if its not invoked on MainThread when the popup is showed it will be blank until the user manually resizes of owner window
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    element.Layout(new Rectangle(windowBound.X, windowBound.Y, windowBound.Width, windowBound.Height));
+                    element.ForceLayout();
+                });
             }
         }
     }


### PR DESCRIPTION
On UWP if Layout and ForceLayout  are not invoked on MainThread when the popup is showed it will be blank until the user manually resizes of owner window

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When the popup is showed it will be blank until the user manually resizes of owner window

### :new: What is the new behavior (if this is a feature change)?
The popup shows his content normally

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
