### PR TITLE
add XmlnsDefinition

### DIFF
--- a/Rg.Plugins.Popup/Properties/AssemblyInfo.cs
+++ b/Rg.Plugins.Popup/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using Xamarin.Forms;
+
+[assembly: XmlnsDefinition("http://rotorgames.com", "Rg.Plugins.Popup.Animations")]
+[assembly: XmlnsDefinition("http://rotorgames.com", "Rg.Plugins.Popup.Pages")]
+[assembly: XmlnsPrefix("http://rotorgames.com", "rg")]

--- a/Samples/Demo/Pages/FirstPopupPage.xaml
+++ b/Samples/Demo/Pages/FirstPopupPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
-             xmlns:animations="clr-namespace:Rg.Plugins.Popup.Animations;assembly=Rg.Plugins.Popup"
-             x:Class="Demo.Pages.FirstPopupPage">
-  <pages:PopupPage.Animation>
-    <animations:ScaleAnimation 
+<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              xmlns:rg="http://rotorgames.com"
+              x:Class="Demo.Pages.FirstPopupPage">
+  <rg:PopupPage.Animation>
+    <rg:ScaleAnimation 
       PositionIn="Center"
       PositionOut="Center"
       ScaleIn="1.2"
@@ -15,7 +14,7 @@
       EasingIn="SinOut"
       EasingOut="SinIn"
       HasBackgroundAnimation="True"/>
-  </pages:PopupPage.Animation>
+  </rg:PopupPage.Animation>
   <StackLayout VerticalOptions="Center" HorizontalOptions="FillAndExpand" Padding="20, 20, 20, 20">
     <StackLayout BackgroundColor="White" Padding="0, 10, 0, 0">
       <Label Text="First Popup Page" TextColor="Gray" FontSize="20" HorizontalOptions="Center"></Label>
@@ -39,4 +38,4 @@
       </ScrollView>
     </StackLayout>
   </StackLayout>
-</pages:PopupPage>
+</rg:PopupPage>

--- a/Samples/Demo/Pages/ListViewPage.xaml
+++ b/Samples/Demo/Pages/ListViewPage.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
+              xmlns:rg="http://rotorgames.com"
              x:Class="Demo.Pages.ListViewPage">
   <StackLayout VerticalOptions="Center" HorizontalOptions="FillAndExpand" Padding="20, 20, 20, 20">
     <StackLayout BackgroundColor="White">
@@ -15,4 +15,4 @@
     </StackLayout>
     <Button Text="Close" TextColor="#A9D1DE" Clicked="OnClose"></Button>
   </StackLayout>
-</pages:PopupPage>
+</rg:PopupPage>

--- a/Samples/Demo/Pages/LoadingPopupPage.xaml
+++ b/Samples/Demo/Pages/LoadingPopupPage.xaml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
-             x:Class="Demo.Pages.LoadingPopupPage"
-             CloseWhenBackgroundIsClicked="False">
+<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              xmlns:rg="http://rotorgames.com"
+              x:Class="Demo.Pages.LoadingPopupPage"
+              CloseWhenBackgroundIsClicked="False">
   <ActivityIndicator
     Color="White"
     IsRunning="True"
@@ -12,4 +12,4 @@
     HorizontalOptions="Center"
     HeightRequest="70"
     WidthRequest="70"/>
-</pages:PopupPage>
+</rg:PopupPage>

--- a/Samples/Demo/Pages/LoginPopupPage.xaml
+++ b/Samples/Demo/Pages/LoginPopupPage.xaml
@@ -1,26 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
-             xmlns:animations="clr-namespace:Rg.Plugins.Popup.Animations;assembly=Rg.Plugins.Popup"
-             x:Class="Demo.Pages.LoginPopupPage">
-  <pages:PopupPage.Resources>
+<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              xmlns:rg="http://rotorgames.com"
+              x:Class="Demo.Pages.LoginPopupPage">
+  <rg:PopupPage.Resources>
     <ResourceDictionary>
       <Style x:Key="EntryStyle" TargetType="Entry">
         <Setter Property="PlaceholderColor" Value="#9cdaf1"/>
         <Setter Property="TextColor" Value="#7dbbe6"/>
       </Style>
     </ResourceDictionary>
-  </pages:PopupPage.Resources>
-  <pages:PopupPage.Animation>
-    <animations:ScaleAnimation
+  </rg:PopupPage.Resources>
+  <rg:PopupPage.Animation>
+    <rg:ScaleAnimation
       PositionIn="Bottom"
       PositionOut="Center"
       ScaleIn="1"
       ScaleOut="0.7"
       DurationIn="700"
       EasingIn="BounceOut"/>
-  </pages:PopupPage.Animation>
+  </rg:PopupPage.Animation>
   <ScrollView
     HorizontalOptions="Center"
     VerticalOptions="Center">
@@ -93,4 +92,4 @@
       </ContentView>
     </AbsoluteLayout>
   </ScrollView>
-</pages:PopupPage>
+</rg:PopupPage>

--- a/Samples/Demo/Pages/LoginSuccessPopupPage.xaml
+++ b/Samples/Demo/Pages/LoginSuccessPopupPage.xaml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<pages:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
-             xmlns:animations="clr-namespace:Rg.Plugins.Popup.Animations;assembly=Rg.Plugins.Popup"
-             x:Class="Demo.Pages.LoginSuccessPopupPage"
-             x:Name="ThisPage"
-             BackgroundColor="Transparent"
-             BackgroundInputTransparent="True"
-             HasSystemPadding="False"
-             CloseWhenBackgroundIsClicked="False">
-  <pages:PopupPage.Animation>
-    <animations:MoveAnimation
+<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              xmlns:rg="http://rotorgames.com"
+              x:Class="Demo.Pages.LoginSuccessPopupPage"
+              x:Name="ThisPage"
+              BackgroundColor="Transparent"
+              BackgroundInputTransparent="True"
+              HasSystemPadding="False"
+              CloseWhenBackgroundIsClicked="False">
+  <rg:PopupPage.Animation>
+    <rg:MoveAnimation
       PositionIn="Top"
       PositionOut="Top"/>
-  </pages:PopupPage.Animation>
+  </rg:PopupPage.Animation>
   <StackLayout
     VerticalOptions="Start"
     BackgroundColor="#43A047">
@@ -25,4 +24,4 @@
       VerticalOptions="EndAndExpand"
       Text="Login is success"/>
   </StackLayout>
-</pages:PopupPage>
+</rg:PopupPage>

--- a/Samples/Demo/Pages/SystemOffsetPage.xaml
+++ b/Samples/Demo/Pages/SystemOffsetPage.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<pages:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
-             x:Class="Demo.Pages.SystemOffsetPage">
+<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              xmlns:rg="http://rotorgames.com"
+              x:Class="Demo.Pages.SystemOffsetPage">
   <ContentView VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" Padding="5,5,5,5" BackgroundColor="Red">
     <ContentView BackgroundColor="White" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
       <StackLayout VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand">
@@ -12,4 +12,4 @@
       </StackLayout>
     </ContentView>
   </ContentView>
-</pages:PopupPage>
+</rg:PopupPage>

--- a/Samples/Demo/Pages/UserAnimationPage.xaml
+++ b/Samples/Demo/Pages/UserAnimationPage.xaml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
-             xmlns:animations="clr-namespace:Demo.Animations;assembly=Demo"
-             x:Class="Demo.Pages.UserAnimationPage">
-  <pages:PopupPage.Animation>
+<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              xmlns:rg="http://rotorgames.com"
+              xmlns:animations="clr-namespace:Demo.Animations;assembly=Demo"
+              x:Class="Demo.Pages.UserAnimationPage">
+  <rg:PopupPage.Animation>
     <animations:UserAnimation/>
-  </pages:PopupPage.Animation>
+  </rg:PopupPage.Animation>
   <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
     <Frame BackgroundColor="Silver">
       <StackLayout Spacing="20">
@@ -15,4 +15,4 @@
       </StackLayout>
     </Frame>
   </StackLayout>
-</pages:PopupPage>
+</rg:PopupPage>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? 

Adds the XmlnsDefinition to make it even easier to use PopupPage's and Animations. 


### :arrow_heading_down: What is the current behavior?

In order to use PopupPages and Animations in XAML you would need to add to XML namespaces, and each would need to be fully qualified with the CLR namespace and assembly.

### :new: What is the new behavior (if this is a feature change)?

You can now simply add a single friendly namespace like:

```xml
<rg:PopupPage xmlns:rg="http://rotorgames.com">
```

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing

n/a

### :memo: Links to relevant issues/docs

- resolves #432

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
