### PR TITLE
(iOS) Fix freezing under xamarin forms 5.0.0.1558-pre3

### DIFF
--- a/Rg.Plugins.Popup/Animations/Base/BaseAnimation.cs
+++ b/Rg.Plugins.Popup/Animations/Base/BaseAnimation.cs
@@ -4,6 +4,8 @@ using Rg.Plugins.Popup.Interfaces.Animations;
 using Rg.Plugins.Popup.Pages;
 using Xamarin.Forms;
 
+using EasingTypeConverter = Rg.Plugins.Popup.Converters.TypeConverters.EasingTypeConverter;
+
 namespace Rg.Plugins.Popup.Animations.Base
 {
     public abstract class BaseAnimation : IPopupAnimation

--- a/Rg.Plugins.Popup/Platforms/Android/Renderers/PopupPageRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Android/Renderers/PopupPageRenderer.cs
@@ -68,7 +68,8 @@ namespace Rg.Plugins.Popup.Droid.Renderers
             var decoreHeight = decoreView.Height;
             var decoreWidht = decoreView.Width;
 
-            var visibleRect = new Rect();
+            var visibleRect = new Android.Graphics.Rect();
+
             decoreView.GetWindowVisibleDisplayFrame(visibleRect);
 
             if (Build.VERSION.SdkInt >= BuildVersionCodes.M)

--- a/Rg.Plugins.Popup/Platforms/Ios/Extensions/PlatformExtension.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Extensions/PlatformExtension.cs
@@ -61,13 +61,15 @@ namespace Rg.Plugins.Popup.IOS.Extensions
                 Right = applactionFrame.Right - applactionFrame.Width - applactionFrame.Left,
                 Bottom = applactionFrame.Bottom - applactionFrame.Height - applactionFrame.Top + renderer.KeyboardBounds.Height
             };
+            if (currentElement.SystemPadding != systemPadding && renderer.Element.Width != superviewFrame.Width && renderer.Element.Height != superviewFrame.Height)
+            {
+                currentElement.BatchBegin();
 
-            currentElement.BatchBegin();
+                currentElement.SystemPadding = systemPadding;
+                renderer.SetElementSize(new Size(superviewFrame.Width, superviewFrame.Height));
 
-            currentElement.SystemPadding = systemPadding;
-            renderer.SetElementSize(new Size(superviewFrame.Width, superviewFrame.Height));
-
-            currentElement.BatchCommit();
+                currentElement.BatchCommit();
+            }
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR allows Rg.Plugins.Popup to run with xamarin forms 5.0.0.1558-pre3 for iOS

### :arrow_heading_down: What is the current behavior?
Currently, on iOS the latest version of rg will freeze as soon as a popup is opened.

### :new: What is the new behavior (if this is a feature change)?
Now, the Popups open as normal.

Also, I added small fixes for ambiguity checks in some files, as it seems the latest pre-release has introduced new types.

### :boom: Does this PR introduce a breaking change?
N/A

### :bug: Recommendations for testing
use the latest demo

### :memo: Links to relevant issues/docs
#589 
### :thinking: Checklist before submitting

**- [ ] All projects build** 
I am unsure with Tizen if this is correct, but to make it build I replaced 
`private Rect? ContentBound => Platform.GetRenderer(PopupPage.Content)?.NativeView.Geometry;`
with
`private ElmSharp.Rect? ContentBound => Platform.GetRenderer(PopupPage.Content)?.NativeView.Geometry;`

in the file
`/Platforms/Tizen/Renderers/PopupPageRenderer.cs`

**Also, I have no tested the android changes yet as I haven't had an available device to do so. Ill attempt as soon as possible**


- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
