### PR TITLE
fix WPF Popup position.

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Wpf/Renderers/PopupPageRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Wpf/Renderers/PopupPageRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Controls.Primitives;
 using Rg.Plugins.Popup.Pages;
 using Rg.Plugins.Popup.WPF.Renderers;
 using Xamarin.Forms;
@@ -21,6 +22,7 @@ namespace Rg.Plugins.Popup.WPF.Renderers
         internal void Prepare(WinPopup container)
         {
             Container = container;
+            Container.Placement = PlacementMode.Absolute;
 
             if (Application.Current.MainWindow != null)
                 Application.Current.MainWindow.SizeChanged += OnSizeChanged;
@@ -74,8 +76,8 @@ namespace Rg.Plugins.Popup.WPF.Renderers
             CurrentElement.Layout(rectangle);
 
             CurrentElement.BatchCommit();
-            Container.VerticalOffset = rectangle.X;
-            Container.HorizontalOffset = rectangle.Y;
+            Container.VerticalOffset = rectangle.Y;
+            Container.HorizontalOffset = rectangle.X;
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)


### :arrow_heading_down: What is the current behavior?

The display location of "Popup" is incorrect in WPF.

### :new: What is the new behavior (if this is a feature change)?

"Popup" is displayed on top of "MainWindow".

### :boom: Does this PR introduce a breaking change?

NO

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
