### PR TITLE
Quickfix for iOS crashing regression

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
@@ -77,7 +77,6 @@ namespace Rg.Plugins.Popup.IOS.Impl
             if (renderer != null && viewController != null && !viewController.IsBeingDismissed)
             {
                 var window = viewController.View?.Window;
-                DisposeModelAndChildrenRenderers(page);
                 page.Parent = null;
                 if (window != null)
                 {
@@ -85,6 +84,7 @@ namespace Rg.Plugins.Popup.IOS.Impl
                     if (rvc != null)
                     {
                         await rvc.DismissViewControllerAsync(false);
+                        DisposeModelAndChildrenRenderers(page);
                         rvc.Dispose();
                     }
                     window.RootViewController = null;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for crashing on popup close for iOS.

Suggesting releasing as 2.0.0.9-alpha for a quick turn around, since I haven't gone through and checked if the 2.0.0.8 release has other bugs associated.


### :bug: Recommendations for testing
Launch demo app
Open popup.
Close it.

### :memo: Links to relevant issues/docs
#613 and possibly part of #613

### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
