### PR TITLE
Page null check in  RemoveAsync for IOS

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
@@ -65,6 +65,10 @@ namespace Rg.Plugins.Popup.IOS.Impl
 
         public async Task RemoveAsync(PopupPage page)
         {
+          
+           if (page == null)
+                return;
+                
             var renderer = XFPlatform.GetRenderer(page);
             var viewController = renderer?.ViewController;
 

--- a/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
@@ -78,20 +78,23 @@ namespace Rg.Plugins.Popup.IOS.Impl
 
             if (renderer != null && viewController != null && !viewController.IsBeingDismissed)
             {
-                var window = viewController.View.Window;
-                await window.RootViewController.DismissViewControllerAsync(false);
-                DisposeModelAndChildrenRenderers(page);
-                window.RootViewController.Dispose();
-                window.RootViewController = null;
-                page.Parent = null;
-                window.Hidden = true;
-
-                if (IsiOS13OrNewer && _windows.Contains(window))
+                var window = viewController.View?.Window;
+                if (window?.RootViewController != null)
+                {
+                    await window.RootViewController.DismissViewControllerAsync(false);
+                    DisposeModelAndChildrenRenderers(page);
+                    window.RootViewController.Dispose();
+                    window.RootViewController = null;
+                    page.Parent = null;
+                    window.Hidden = true;
+                    if (IsiOS13OrNewer && _windows.Contains(window))
                     _windows.Remove(window);
 
-                window.Dispose();
-                window = null;
-
+                    window.Dispose();
+                    window = null;
+                }
+                
+               
                 if (UIApplication.SharedApplication.KeyWindow.WindowLevel == -1)
                     UIApplication.SharedApplication.KeyWindow.WindowLevel = UIWindowLevel.Normal;
             }


### PR DESCRIPTION
some cases page is null on Ios, not sure why but it crashes the application, a simple null check won't harm i believe.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

null check

### :arrow_heading_down: What is the current behavior?

if page is null, it crashes the Ios app.

### :new: What is the new behavior (if this is a feature change)?

it won't crash at least but will do just nothing

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing

n/a

### :memo: Links to relevant issues/docs

n/a

### :thinking: Checklist before submitting

- [x ] All projects build
- [x ] Follows style guide lines 
- [ x] Relevant documentation was updated
- [ x] Rebased onto current master
