### PR TITLE
Setting UIWindowLevel.Normal during removal

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
@@ -105,7 +105,10 @@ namespace Rg.Plugins.Popup.IOS.Impl
                     window.Dispose();
                     window = null;
                 }
-                if (UIApplication.SharedApplication.KeyWindow.WindowLevel == -1 && _windows.Count == 0)
+
+                if(_windows.Count > 0)
+                    _windows.Last().WindowLevel = UIWindowLevel.Normal;
+                else if (UIApplication.SharedApplication.KeyWindow.WindowLevel == -1)
                     UIApplication.SharedApplication.KeyWindow.WindowLevel = UIWindowLevel.Normal;
             }
         }

--- a/Samples/Demo/Demo.csproj
+++ b/Samples/Demo/Demo.csproj
@@ -16,6 +16,7 @@
   
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Samples/Demo/Pages/MainPage.xaml
+++ b/Samples/Demo/Pages/MainPage.xaml
@@ -23,5 +23,6 @@
               Clicked="OnOpenUserAnimationFromStyle"></Button>
       <Button Text="Open Settings" Clicked="OnOpenSettingsPage"></Button>
       <Button Text="Open MvvmPage" Clicked="OnOpenMvvmPage"></Button>
+      <Button Text="Open TestCurrentViewController" Clicked="OnTestCurrentViewController"></Button>
     </StackLayout>
 </ContentPage>

--- a/Samples/Demo/Pages/MainPage.xaml.cs
+++ b/Samples/Demo/Pages/MainPage.xaml.cs
@@ -74,5 +74,12 @@ namespace Demo.Pages
             
             await PopupNavigation.Instance.PushAsync(page);
         }
+
+        private async void OnTestCurrentViewController(object sender, EventArgs e)
+        {
+            var page = new TestCurrentViewController(0);
+
+            await PopupNavigation.Instance.PushAsync(page);
+        }
     }
 }

--- a/Samples/Demo/Pages/TestCurrentViewController.xaml
+++ b/Samples/Demo/Pages/TestCurrentViewController.xaml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              xmlns:rg="http://rotorgames.com"
+              xmlns:animations="clr-namespace:Demo.Animations;assembly=Demo"
+              x:Class="Demo.Pages.TestCurrentViewController">
+
+  <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
+    <Frame BackgroundColor="Silver">
+      <StackLayout Spacing="20">
+        <Label HorizontalOptions="Center" Text="index" FontSize="16"></Label>
+        <Label HorizontalOptions="Center" FontSize="16" x:Name="indexLable"></Label>
+        <Button Text="Open TestCurrentViewController" Clicked="OnTestCurrentViewController"></Button>
+        <Button Text="Open file picker" Clicked="OnFilePicker"></Button>
+      </StackLayout>
+    </Frame>
+  </StackLayout>
+</rg:PopupPage>

--- a/Samples/Demo/Pages/TestCurrentViewController.xaml.cs
+++ b/Samples/Demo/Pages/TestCurrentViewController.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Rg.Plugins.Popup.Pages;
+using Rg.Plugins.Popup.Services;
+
+namespace Demo.Pages
+{
+    public partial class TestCurrentViewController : PopupPage
+    {
+        private int index = 0;
+
+        public TestCurrentViewController(int index)
+        {
+            InitializeComponent();
+            this.index = index;
+            indexLable.Text = this.index.ToString();
+        }
+
+        private async void OnTestCurrentViewController(object sender, EventArgs e)
+        {
+            var page = new TestCurrentViewController(index + 1);
+
+            await PopupNavigation.Instance.PushAsync(page);
+        }
+
+        private async void OnFilePicker(object sender, EventArgs e)
+        {
+            var file = await Xamarin.Essentials.FilePicker.PickAsync();
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce?
This PR fixed issue #658.

I also added [TestCurrentViewController page](https://github.com/dimonovdd/Rg.Plugins.Popup/blob/0d46f10e49378db6dc6835f35f7cc4888b8c3888/Samples/Demo/Pages/TestCurrentViewController.xaml.cs) and the [reference to Xamarin.Essentials](https://github.com/dimonovdd/Rg.Plugins.Popup/blob/0d46f10e49378db6dc6835f35f7cc4888b8c3888/Samples/Demo/Demo.csproj#L19), which we can delete after merging.

### :arrow_heading_down: What is the current behavior?
There was no way to get the current window

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
see related issue

### :memo: Links to relevant issues
#658 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
