### PR TITLE
Fix: Fix the popup windows issues for iOS 13+ when the multi scene is enabled

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Impl/PopupPlatformIos.cs
@@ -55,10 +55,19 @@ namespace Rg.Plugins.Popup.IOS.Impl
 
             var renderer = page.GetOrCreateRenderer();
 
-            var window = new PopupWindow();
-
+            PopupWindow window;
             if (IsiOS13OrNewer)
+            {
+                var connectedScene = UIApplication.SharedApplication.ConnectedScenes.ToArray().FirstOrDefault(x => x.ActivationState == UISceneActivationState.ForegroundActive);
+                if (connectedScene != null && connectedScene is UIWindowScene windowScene)
+                    window = new PopupWindow(windowScene);
+                else
+                    window = new PopupWindow();
+
                 _windows.Add(window);
+            }
+            else
+                window = new PopupWindow();
 
             window.BackgroundColor = Color.Transparent.ToUIColor();
             window.RootViewController = new PopupPlatformRenderer(renderer);

--- a/Rg.Plugins.Popup/Platforms/Ios/Platform/PopupWindow.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Platform/PopupWindow.cs
@@ -20,6 +20,11 @@ namespace Rg.Plugins.Popup.IOS.Platform
 
         }
 
+        public PopupWindow(UIWindowScene uiWindowScene) : base(uiWindowScene)
+        {
+
+        }
+
         public override UIView HitTest(CGPoint point, UIEvent? uievent)
         {
             var platformRenderer = (PopupPlatformRenderer?)RootViewController;


### PR DESCRIPTION
… enabled

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Currently the popup is not showing in iOS 13+ if the app is configured as multi scenes.

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Setup the "UIApplicationSceneManifest" in Info.plist and check the popup demo

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [ ] Rebased onto current develop
