### PR TITLE
Accessibility upgrade585

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
+++ b/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
@@ -103,7 +103,7 @@ namespace Rg.Plugins.Popup.Droid.Impl
                 {
                     var navCount = XApplication.Current.MainPage.Navigation.NavigationStack.Count;
                     var modalCount = XApplication.Current.MainPage.Navigation.ModalStack.Count;
-                    XApplication.Current.MainPage.GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.NoHideDescendants;
+                    XApplication.Current.MainPage.GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
 
                     if (navCount > 0)
                     {

--- a/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
+++ b/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
@@ -56,9 +56,19 @@ namespace Rg.Plugins.Popup.Droid.Impl
             {
                 if (page.AndroidTalkbackAccessibilityWorkaround)
                 {
-                    var NavCount = XApplication.Current.MainPage.Navigation.NavigationStack.Count;
-                    Page currentPage = XApplication.Current.MainPage.Navigation.NavigationStack[NavCount - 1];
-                    currentPage.GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.NoHideDescendants;
+                    var navCount = XApplication.Current.MainPage.Navigation.NavigationStack.Count;
+                    var modalCount = XApplication.Current.MainPage.Navigation.ModalStack.Count;
+                    XApplication.Current.MainPage.GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.NoHideDescendants;
+
+                    if (navCount > 0)
+                    {
+                        XApplication.Current.MainPage.Navigation.NavigationStack[navCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.NoHideDescendants;
+                    }
+                    if (modalCount > 0)
+                    {
+                        XApplication.Current.MainPage.Navigation.ModalStack[modalCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.NoHideDescendants;
+                    }
+
                 }
             }
         }
@@ -91,9 +101,18 @@ namespace Rg.Plugins.Popup.Droid.Impl
             {
                 if (page.AndroidTalkbackAccessibilityWorkaround)
                 {
-                    var NavCount = XApplication.Current.MainPage.Navigation.NavigationStack.Count;
-                    Page currentPage = XApplication.Current.MainPage.Navigation.NavigationStack[NavCount - 1];
-                    currentPage.GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
+                    var navCount = XApplication.Current.MainPage.Navigation.NavigationStack.Count;
+                    var modalCount = XApplication.Current.MainPage.Navigation.ModalStack.Count;
+                    XApplication.Current.MainPage.GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.NoHideDescendants;
+
+                    if (navCount > 0)
+                    {
+                        XApplication.Current.MainPage.Navigation.NavigationStack[navCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
+                    }
+                    if (modalCount > 0)
+                    {
+                        XApplication.Current.MainPage.Navigation.ModalStack[modalCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This fixes small bugs in the accessibility workaround, when users do not overlay a second page on their main-age and instead swap them out.

### :arrow_heading_down: What is the current behavior?
Currently the app will crash if there isnt 2 pages on the stack

### :new: What is the new behavior (if this is a feature change)?
It no longer crashes, and it should also work with modals

### :boom: Does this PR introduce a breaking change?
n/a

### :bug: Recommendations for testing
go through and test the app presented in #681 

### :memo: Links to relevant issues/docs
#681
#585  

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
