### PR TITLE
Android page title accessibility issue

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
+++ b/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 using Android.App;
-using Android.Content;
 using Android.OS;
 using Android.Provider;
 using Android.Runtime;
 using Android.Views;
-using Android.Views.Accessibility;
 using Android.Widget;
 
 using Rg.Plugins.Popup.Contracts;
@@ -17,7 +13,6 @@ using Rg.Plugins.Popup.Droid.Extensions;
 using Rg.Plugins.Popup.Droid.Impl;
 using Rg.Plugins.Popup.Exceptions;
 using Rg.Plugins.Popup.Pages;
-using Rg.Plugins.Popup.Services;
 
 using Xamarin.Forms;
 

--- a/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
+++ b/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -69,6 +70,25 @@ namespace Rg.Plugins.Popup.Droid.Impl
                         XApplication.Current.MainPage.Navigation.ModalStack[modalCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.NoHideDescendants;
                     }
 
+                    DisableFocusableInTouchMode(XApplication.Current.MainPage.GetOrCreateRenderer().View.Parent);
+                }
+            }
+
+            static void DisableFocusableInTouchMode(IViewParent? parent)
+            {
+                var view = parent;
+                string className = $"{view?.GetType().Name}";
+
+                while (!className.Contains("PlatformRenderer") && view != null)
+                {
+                    view = view.Parent;
+                    className = $"{view?.GetType().Name}";
+                }
+
+                if (view is Android.Views.View androidView)
+                {
+                    androidView.Focusable = false;
+                    androidView.FocusableInTouchMode = false;
                 }
             }
         }

--- a/Samples/Demo/Pages/UserAnimationPage.xaml
+++ b/Samples/Demo/Pages/UserAnimationPage.xaml
@@ -1,18 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<rg:PopupPage xmlns="http://xamarin.com/schemas/2014/forms"
+<rg:PopupPage x:Class="Demo.Pages.UserAnimationPage"
+              xmlns="http://xamarin.com/schemas/2014/forms"
               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-              xmlns:rg="http://rotorgames.com"
               xmlns:animations="clr-namespace:Demo.Animations;assembly=Demo"
-              x:Class="Demo.Pages.UserAnimationPage">
-  <rg:PopupPage.Animation>
-    <animations:UserAnimation/>
-  </rg:PopupPage.Animation>
-  <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
-    <Frame BackgroundColor="Silver">
-      <StackLayout Spacing="20">
-        <Label HorizontalOptions="Center" Text="User Animation" FontSize="16"></Label>
-        <Button Text="Close" Clicked="OnClose"></Button>
-      </StackLayout>
-    </Frame>
-  </StackLayout>
+              xmlns:rg="http://rotorgames.com"
+              AndroidTalkbackAccessibilityWorkaround="True">
+    <rg:PopupPage.Animation>
+        <animations:UserAnimation />
+    </rg:PopupPage.Animation>
+    <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+        <Frame BackgroundColor="Silver">
+            <StackLayout Spacing="20">
+                <Label FontSize="16"
+                       HorizontalOptions="Center"
+                       Text="User Animation" />
+                <Button Clicked="OnClose" Text="Close" />
+            </StackLayout>
+        </Frame>
+    </StackLayout>
 </rg:PopupPage>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug _(semi)_ fix


### :arrow_heading_down: What is the current behavior?
Underlining page title can be read out when the popup is open

### :new: What is the new behaviour (if this is a feature change)?
This sort of fixes the issue. In the demo app, the title still gets readout but only the page title is selectable whereas previously the page + page title was selectable.

Here is a vid -
|Before | After |
|-----|-----|
|https://user-images.githubusercontent.com/6544051/126693591-00069429-4f50-4835-8400-701c963bd02d.mp4|https://user-images.githubusercontent.com/6544051/126693656-2d96e16d-9298-40b2-bbbf-1fe9451e7d72.mp4|

**BUT** it has completely fixed the issue in the repo project attached to the linked issue. So not sure how the demo project differs from that.

@LuckyDucko sorry it's not a complete fix, but hopefully, it helps. For reference found the code in this repo - https://github.com/PureWeen/A11YTools/blob/680c223d2e52d2c07cf50ab1801de5d4450ae2c2/A11YTools/A11YTools.Android/AccessiblePageRenderer.cs#L42

### :boom: Does this PR introduce a breaking change?
Not that I can think of

### :memo: Links to relevant issues/docs
#681 


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
