### PR TITLE
Fix XamlParseException type converter

### DIFF
--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Converters/TypeConverters/EasingTypeConverter.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Converters/TypeConverters/EasingTypeConverter.cs
@@ -3,6 +3,7 @@ using Microsoft.Maui;
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -10,14 +11,14 @@ namespace Rg.Plugins.Popup.Converters.TypeConverters
 {
     public class EasingTypeConverter : TypeConverter
     {
-        public new object? ConvertFromInvariantString(string value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             if (value != null)
             {
                 FieldInfo? fieldInfo = typeof(Easing).GetRuntimeFields()?.FirstOrDefault(fi =>
                 {
                     if (fi.IsStatic)
-                        return fi.Name == value;
+                        return fi.Name == value.ToString();
                     return false;
                 });
                 if (fieldInfo != null)

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Converters/TypeConverters/UintTypeConverter.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Converters/TypeConverters/UintTypeConverter.cs
@@ -1,12 +1,13 @@
 ﻿
 using System;
 using System.ComponentModel;
+using System.Globalization;
 
 namespace Rg.Plugins.Popup.Converters.TypeConverters
 {
     public class UintTypeConverter : TypeConverter
     {
-        public new object ConvertFromInvariantString(string value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             try
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix


### :arrow_heading_down: What is the current behavior?
Crashing XamlParseException

### :new: What is the new behavior (if this is a feature change)?
This is not a feature change because user do not directly affected by this change, unless they are inheriting this type because maui uses `System.ComponentModel.TypeConverter` instead of creating their own type converter which Xamarin.Forms do right now

### :boom: Does this PR introduce a breaking change?
No, unless they are inheriting this type

### :bug: Recommendations for testing
Try changing `DurationIn`, `DurationOut`, `EasingIn`, `EasingOut`

### :memo: Links to relevant issues/docs
https://github.com/rotorgames/Rg.Plugins.Popup/issues/684#issuecomment-930817567

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
