### PR TITLE
Add back button handling in Sample

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -83,8 +83,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="AsyncFixer" Version="1.3.0" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="3.2.2" PrivateAssets="all" />
+    <PackageReference Include="AsyncFixer" Version="1.5.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" PrivateAssets="all" />
   </ItemGroup>
   

--- a/Rg.Popup.Plugin.Maui/SampleMaui/MauiProgram.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/MauiProgram.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls.Compatibility;
+﻿using Microsoft.Maui;
 using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Hosting;
-
-using Rg.Plugins.Popup.Contracts;
+using Microsoft.Maui.LifecycleEvents;
+using Rg.Plugins.Popup;
 
 namespace SampleMaui
 {
@@ -12,17 +10,20 @@ namespace SampleMaui
     {
         public static MauiApp CreateMauiApp()
         {
-
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-                });
-#if __ANDROID__
-            Microsoft.Maui.Essentials.Platform.Init(MauiApplication.Current);
+                })
+                .ConfigureLifecycleEvents(lifecycle =>
+                {
+#if ANDROID
+                    lifecycle.AddAndroid(d => d.OnBackPressed(activity => Popup.SendBackPressed(activity.OnBackPressed)));
 #endif
+                });
+
             return builder.Build();
         }
     }

--- a/Rg.Popup.Plugin.Maui/SampleMaui/Platforms/Android/MainApplication.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/Platforms/Android/MainApplication.cs
@@ -13,6 +13,7 @@ namespace SampleMaui
         public MainApplication(IntPtr handle, JniHandleOwnership ownership)
             : base(handle, ownership)
         {
+            Microsoft.Maui.Essentials.Platform.Init(Current);
         }
 
         protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();


### PR DESCRIPTION
Sample has many things disabled for setting up if the main package works.
removing legacy code
changing code to make better sense, in my opinion, however this may lead to more bugs.### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)


### :arrow_heading_down: What is the current behavior?

Popups in Sample don't react on back button

### :new: What is the new behavior (if this is a feature change)?

- Sample now handles back button
- Moved `Essentials.Init` to `MainApplication` to not clatter `MauiProgram` with `#if`s, and I hope it won't be needed when MAUI releases anyway. Totally subjective opinion, `Init` can be moved back in `MauiProgram`

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#684

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
