### PR TITLE
Fixed NaN issues with Android 9 and 10 when using multiple popups

### DIFF
--- a/Rg.Plugins.Popup/Animations/ScaleAnimation.cs
+++ b/Rg.Plugins.Popup/Animations/ScaleAnimation.cs
@@ -102,10 +102,13 @@ namespace Rg.Plugins.Popup.Animations
         public async override Task Disappearing(View content, PopupPage page)
         {
             var taskList = new List<Task>();
+
+            taskList.Add(base.Disappearing(content, page));
+
             if (content != null)
             {
                 UpdateDefaultProperties(content);
-                taskList.Add(base.Disappearing(content, page));
+
                 var topOffset = GetTopOffset(content, page) * ScaleOut;
                 var leftOffset = GetLeftOffset(content, page) * ScaleOut;
 

--- a/Rg.Plugins.Popup/Animations/ScaleAnimation.cs
+++ b/Rg.Plugins.Popup/Animations/ScaleAnimation.cs
@@ -102,13 +102,10 @@ namespace Rg.Plugins.Popup.Animations
         public async override Task Disappearing(View content, PopupPage page)
         {
             var taskList = new List<Task>();
-
-            taskList.Add(base.Disappearing(content, page));
-
             if (content != null)
             {
                 UpdateDefaultProperties(content);
-
+                taskList.Add(base.Disappearing(content, page));
                 var topOffset = GetTopOffset(content, page) * ScaleOut;
                 var leftOffset = GetLeftOffset(content, page) * ScaleOut;
 
@@ -131,7 +128,6 @@ namespace Rg.Plugins.Popup.Animations
                     taskList.Add(content.TranslateTo(leftOffset, _defaultTranslationY, DurationOut, EasingOut));
                 }
             }
-
             await Task.WhenAll(taskList);
         }
 
@@ -141,7 +137,7 @@ namespace Rg.Plugins.Popup.Animations
 
             content.Animate("popIn", d =>
             {
-                content.Scale = d;
+                content.Scale = double.IsNaN(d) ? 1 : d;
             }, start, end,
             easing: easing,
             length: isAppearing ? DurationIn : DurationOut,

--- a/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
+++ b/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
@@ -18,7 +18,7 @@
     <Description>Plugin for Xamarin forms. Allows you to open any page as a popup.</Description>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <UseWPF Condition=" '$(OS)' == 'Windows_NT' ">true</UseWPF>
-    <Version>2.0.0.13</Version>
+    <Version>2.0.0.14</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap')) And '$(OS)' == 'Windows_NT'">

--- a/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
+++ b/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
@@ -18,7 +18,7 @@
     <Description>Plugin for Xamarin forms. Allows you to open any page as a popup.</Description>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <UseWPF Condition=" '$(OS)' == 'Windows_NT' ">true</UseWPF>
-    <Version>2.0.0.12</Version>
+    <Version>2.0.0.13</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap')) And '$(OS)' == 'Windows_NT'">

--- a/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
+++ b/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
@@ -18,6 +18,7 @@
     <Description>Plugin for Xamarin forms. Allows you to open any page as a popup.</Description>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <UseWPF Condition=" '$(OS)' == 'Windows_NT' ">true</UseWPF>
+    <Version>2.0.0.12</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap')) And '$(OS)' == 'Windows_NT'">

--- a/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
+++ b/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
@@ -18,7 +18,6 @@
     <Description>Plugin for Xamarin forms. Allows you to open any page as a popup.</Description>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <UseWPF Condition=" '$(OS)' == 'Windows_NT' ">true</UseWPF>
-    <Version>2.0.0.14</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap')) And '$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Issues on Android 9 and 10 when starting multiple popups with animations

### :new: What is the new behavior (if this is a feature change)?
Works properly on 8, 9, 10, 11 (tested)

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Start multiple popups 2-4 and close them down fast.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
