### PR TITLE
#697 iOS 14 with Xamarin.iOS 15.0 Cannot access a disposed 'PopupPa…

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Ios/Renderers/PopupPageRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Renderers/PopupPageRenderer.cs
@@ -109,6 +109,7 @@ namespace Rg.Plugins.Popup.IOS.Renderers
 
         public override void ViewDidLayoutSubviews()
         {
+            if (_isDisposed) return;
             base.ViewDidLayoutSubviews();
             this.UpdateSize();
         }


### PR DESCRIPTION
…geRenderer'

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

- This is a fixe

### :arrow_heading_down: What is the current behavior?

- Disposed Renderers are called, and when I want to interact with an entry inside a new PopupPage
I had this exception when the keyboard want to show up and PopupPage need to resize for keyboard.
                                      <img width="500" alt="Screenshot 2021-10-07 at 00 26 27" src="https://user-images.githubusercontent.com/4518686/136292258-d4f21362-a746-48b2-9308-70c6ef122d9d.png">

### :new: What is the new behavior (if this is a feature change)?

- The layout is well resized when the keyboard appear and no exception!

### :boom: Does this PR introduce a breaking change?

- No

### :bug: Recommendations for testing

- To test is to doubt ;)

### :memo: Links to relevant issues/docs

- #697 

### :thinking: Checklist before submitting

- [✓] All projects build
- [✓] Follows style guide lines 
- [✓] Relevant documentation was updated
- [✓] Rebased onto current develop