### PR TITLE
[iOS] Rg.Plugins.Popup 2.0.0.14 : Null Reference Exception

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Ios/Extensions/PlatformExtension.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Extensions/PlatformExtension.cs
@@ -61,7 +61,8 @@ namespace Rg.Plugins.Popup.IOS.Extensions
 
             Thickness systemPadding;
 
-            if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+            if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0)
+                && UIApplication.SharedApplication.KeyWindow != null)
             {
                 var safeAreaInsets = UIApplication.SharedApplication.KeyWindow.SafeAreaInsets;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Handle a Null Reference Exception on KeyWindow object.

### :arrow_heading_down: What is the current behavior?

Normal

### :new: What is the new behavior (if this is a feature change)?

No Change

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Build on iOS and check if a Null Reference is raising.

### :memo: Links to relevant issues/docs

#708 

### :thinking: Checklist before submitting

- [✔] All projects build
- [✔] Follows style guide lines 
- [✔] Relevant documentation was updated
- [✔] Rebased onto current develop
