### PR TITLE
[MAUI] Preview 11

### DIFF
--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/Base/BaseAnimation.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/Base/BaseAnimation.cs
@@ -1,14 +1,8 @@
 ﻿
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-
+using System.ComponentModel;
 using Rg.Plugins.Popup.Converters.TypeConverters;
 using Rg.Plugins.Popup.Interfaces.Animations;
 using Rg.Plugins.Popup.Pages;
-
-using System.ComponentModel;
-using System.Threading.Tasks;
-
 using EasingTypeConverter = Rg.Plugins.Popup.Converters.TypeConverters.EasingTypeConverter;
 using TypeConverterAttribute = System.ComponentModel.TypeConverterAttribute;
 

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/Base/FadeBackgroundAnimation.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/Base/FadeBackgroundAnimation.cs
@@ -1,10 +1,4 @@
-﻿
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
-
-using Rg.Plugins.Popup.Pages;
-
-using System.Threading.Tasks;
+﻿using Rg.Plugins.Popup.Pages;
 
 namespace Rg.Plugins.Popup.Animations.Base
 {

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/FadeAnimation.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/FadeAnimation.cs
@@ -1,10 +1,5 @@
-﻿using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-
-using Rg.Plugins.Popup.Animations.Base;
+﻿using Rg.Plugins.Popup.Animations.Base;
 using Rg.Plugins.Popup.Pages;
-
-using System.Threading.Tasks;
 
 namespace Rg.Plugins.Popup.Animations
 {

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/MoveAnimation.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/MoveAnimation.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-
+﻿
 using Rg.Plugins.Popup.Animations.Base;
 using Rg.Plugins.Popup.Enums;
 using Rg.Plugins.Popup.Pages;

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/ScaleAnimation.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Animations/ScaleAnimation.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-
+﻿
 using Rg.Plugins.Popup.Enums;
 using Rg.Plugins.Popup.Pages;
 
@@ -146,7 +141,7 @@ namespace Rg.Plugins.Popup.Animations
 
             content.Animate(
                 "popIn",
-                d =>  content.Scale = double.IsNaN(d) ? 1 : d, start, end,
+                d => content.Scale = double.IsNaN(d) ? 1 : d, start, end,
                 easing: easing,
                 length: isAppearing ? DurationIn : DurationOut,
                 finished: (_, _) => task.SetResult(true));

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Contracts/IPopupNavigation.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Contracts/IPopupNavigation.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Rg.Plugins.Popup.Events;
+﻿using Rg.Plugins.Popup.Events;
 using Rg.Plugins.Popup.Pages;
 
 namespace Rg.Plugins.Popup.Contracts

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Contracts/IPopupPlatform.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Contracts/IPopupPlatform.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Rg.Plugins.Popup.Pages;
+﻿using Rg.Plugins.Popup.Pages;
 
 namespace Rg.Plugins.Popup.Contracts
 {

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Converters/TypeConverters/EasingTypeConverter.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Converters/TypeConverters/EasingTypeConverter.cs
@@ -1,10 +1,5 @@
-﻿
-using Microsoft.Maui;
-
-using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 
 namespace Rg.Plugins.Popup.Converters.TypeConverters

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Converters/TypeConverters/UintTypeConverter.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Converters/TypeConverters/UintTypeConverter.cs
@@ -1,6 +1,4 @@
-﻿
-using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Globalization;
 
 namespace Rg.Plugins.Popup.Converters.TypeConverters

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Enums/PaddingSide.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Enums/PaddingSide.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Rg.Plugins.Popup.Enums
+﻿namespace Rg.Plugins.Popup.Enums
 {
     [Flags]
     public enum PaddingSide

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Events/PopupNavigationEventArgs.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Events/PopupNavigationEventArgs.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Rg.Plugins.Popup.Pages;
+﻿using Rg.Plugins.Popup.Pages;
 
 namespace Rg.Plugins.Popup.Events
 {

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Interfaces/Animations/IPopupAnimation.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Interfaces/Animations/IPopupAnimation.cs
@@ -1,9 +1,4 @@
-﻿
-using Microsoft.Maui.Controls;
-
-using Rg.Plugins.Popup.Pages;
-
-using System.Threading.Tasks;
+﻿using Rg.Plugins.Popup.Pages;
 
 namespace Rg.Plugins.Popup.Interfaces.Animations
 {

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Pages/PopupPage.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Pages/PopupPage.cs
@@ -1,17 +1,8 @@
-﻿
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
-
+﻿using AsyncAwaitBestPractices;
 using Rg.Plugins.Popup.Animations;
 using Rg.Plugins.Popup.Enums;
 using Rg.Plugins.Popup.Interfaces.Animations;
 using Rg.Plugins.Popup.Services;
-
-using System;
-using System.Threading.Tasks;
-
-using AsyncAwaitBestPractices;
 namespace Rg.Plugins.Popup.Pages
 {
     public partial class PopupPage : ContentPage
@@ -236,7 +227,7 @@ namespace Rg.Plugins.Popup.Pages
         #endregion
 
         #region Override Animation Methods
-        
+
         protected virtual void OnAppearingAnimationBegin()
         {
         }
@@ -252,7 +243,7 @@ namespace Rg.Plugins.Popup.Pages
         protected virtual void OnDisappearingAnimationEnd()
         {
         }
-        
+
 
         protected virtual Task OnAppearingAnimationBeginAsync()
         {

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Platforms/Android/Renderers/PopupPageRenderer.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Platforms/Android/Renderers/PopupPageRenderer.cs
@@ -12,6 +12,7 @@ using Microsoft.Maui.Graphics;
 using Rg.Plugins.Popup.Pages;
 using Microsoft.Maui.Handlers;
 using System.Threading.Tasks;
+using Microsoft.Maui.Platform;
 
 namespace Rg.Plugins.Popup.Pages
 {
@@ -32,11 +33,9 @@ namespace Rg.Plugins.Popup.Pages
 
                     this.NativeView.LayoutChange += PopupPage_LayoutChange;
                 });
-
             }
-            catch (Exception ex )
+            catch (Exception ex)
             {
-
                 throw;
             }
                 

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui.csproj
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui.csproj
@@ -7,6 +7,7 @@
 		<UseMaui>true</UseMaui>
     <UseMauiEssentials>true</UseMauiEssentials> 
     <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
 
     <AssemblyName>Rg.Plugins.Popup</AssemblyName>
     <RootNamespace>Rg.Plugins.Popup</RootNamespace>

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Services/PopupNavigation.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Services/PopupNavigation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Rg.Plugins.Popup.Contracts;
 
 namespace Rg.Plugins.Popup.Services

--- a/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Services/PopupNavigationImpl.cs
+++ b/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Rg.Popup.Plugin.Maui/Services/PopupNavigationImpl.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
+﻿using AsyncAwaitBestPractices;
 using Rg.Plugins.Popup.Contracts;
 using Rg.Plugins.Popup.Events;
 using Rg.Plugins.Popup.Pages;
-using AsyncAwaitBestPractices;
-using System.Diagnostics;
 
 namespace Rg.Plugins.Popup.Services
 {
@@ -95,7 +90,7 @@ namespace Rg.Plugins.Popup.Services
                 return pushPageTask;
 
                 async Task PushPage()
-                { 
+                {
                     animate = CanBeAnimated(animate);
 
                     if (animate)
@@ -202,7 +197,7 @@ namespace Rg.Plugins.Popup.Services
         // Private
 
         // Internal 
-        
+
         internal void RemovePopupFromStack(PopupPage page) // unused?
         {
             if (_popupStack.Contains(page))

--- a/Rg.Popup.Plugin.Maui/SampleMaui/Animations/UserAnimation.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/Animations/UserAnimation.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-
+﻿
 using Rg.Plugins.Popup.Animations.Base;
 using Rg.Plugins.Popup.Pages;
 

--- a/Rg.Popup.Plugin.Maui/SampleMaui/App.xaml.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/App.xaml.cs
@@ -1,11 +1,5 @@
-﻿using System;
-
+﻿
 //using Demo.Pages;
-
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
-using Microsoft.Maui.Controls.Xaml;
 
 using SampleMaui.CSharpMarkup;
 
@@ -16,7 +10,7 @@ namespace SampleMaui
 {
     public partial class App : Application
     {
-        public App() 
+        public App()
         {
             InitializeComponent();
             MainPage = new MainPage();

--- a/Rg.Popup.Plugin.Maui/SampleMaui/CSharpMarkup/LoginPage.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/CSharpMarkup/LoginPage.cs
@@ -1,48 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Rg.Plugins.Popup.Pages;
+﻿
 using Rg.Plugins.Popup.Animations;
-using Microsoft.Maui.Controls;
+using Rg.Plugins.Popup.Pages;
 using ScrollView = Microsoft.Maui.Controls.ScrollView;
 
 namespace SampleMaui.CSharpMarkup
 {
     public partial class LoginPage : PopupPage
     {
-        public Frame FrameContainer {  get; set; }
+        public Frame FrameContainer { get; set; }
         public Image DotNetBotImage { get; set; }
 
         public Entry UsernameEntry { get; set; }
-        public Entry PasswordEntry {  get; set; }
-        public Microsoft.Maui.Controls.Button LoginButton {  get; set; }
+        public Entry PasswordEntry { get; set; }
+        public Microsoft.Maui.Controls.Button LoginButton { get; set; }
         protected void BuildContent()
         {
             try
             {
 
-            this.HeightRequest = 300;
-            this.WidthRequest = 300;
-            this.Animation = new ScaleAnimation
-            {
-                DurationIn = 700,
-                EasingIn = Microsoft.Maui.Easing.BounceOut,
-                PositionIn = Rg.Plugins.Popup.Enums.MoveAnimationOptions.Bottom,
-                PositionOut = Rg.Plugins.Popup.Enums.MoveAnimationOptions.Center,
-                ScaleIn = 1,
-                ScaleOut = 0.7
-            };
-            this.Content = new ScrollView
-            {
-                WidthRequest = 300,
-                HeightRequest = 300,
-                HorizontalOptions = LayoutOptions.CenterAndExpand,
-                VerticalOptions = LayoutOptions.CenterAndExpand,
-                Content = GenerateLoginView()
-            };
+                this.HeightRequest = 300;
+                this.WidthRequest = 300;
+                this.Animation = new ScaleAnimation
+                {
+                    DurationIn = 700,
+                    EasingIn = Microsoft.Maui.Easing.BounceOut,
+                    PositionIn = Rg.Plugins.Popup.Enums.MoveAnimationOptions.Bottom,
+                    PositionOut = Rg.Plugins.Popup.Enums.MoveAnimationOptions.Center,
+                    ScaleIn = 1,
+                    ScaleOut = 0.7
+                };
+                this.Content = new ScrollView
+                {
+                    WidthRequest = 300,
+                    HeightRequest = 300,
+                    HorizontalOptions = LayoutOptions.CenterAndExpand,
+                    VerticalOptions = LayoutOptions.CenterAndExpand,
+                    Content = GenerateLoginView()
+                };
             }
             catch (Exception)
             {
@@ -64,7 +58,7 @@ namespace SampleMaui.CSharpMarkup
         }
         private StackLayout GenerateFrameContainerContent()
         {
-            var frameContainerContent  = new StackLayout
+            var frameContainerContent = new StackLayout
             {
                 Padding = new Microsoft.Maui.Thickness(10, 5)
             };

--- a/Rg.Popup.Plugin.Maui/SampleMaui/CSharpMarkup/LoginPage.logic.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/CSharpMarkup/LoginPage.logic.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-
+﻿
 using Rg.Plugins.Popup.Pages;
 
 namespace SampleMaui.CSharpMarkup
@@ -16,7 +8,7 @@ namespace SampleMaui.CSharpMarkup
         public LoginPage()
         {
             BuildContent();
-           
+
         }
 
         protected override void OnAppearingAnimationBegin()
@@ -42,7 +34,7 @@ namespace SampleMaui.CSharpMarkup
 
             //CloseImage.Rotation = 30;
             //CloseImage.Scale = 0.3;
-           // CloseImage.Opacity = 0;
+            // CloseImage.Opacity = 0;
 
             //LoginButton.Scale = 0.3;
             //LoginButton.Opacity = 0;
@@ -58,26 +50,26 @@ namespace SampleMaui.CSharpMarkup
                 return;
             }
 
-           // var translateLength = 400u;
-           /*
-            await Task.WhenAll(
-                UsernameEntry.TranslateTo(0, 0, easing: Easing.SpringOut, length: translateLength),
-                UsernameEntry.FadeTo(1),
-                (new Func<Task>(async () =>
-                {
-                    await Task.Delay(200);
-                    await Task.WhenAll(
-                        PasswordEntry.TranslateTo(0, 0, easing: Easing.SpringOut, length: translateLength),
-                        PasswordEntry.FadeTo(1));
+            // var translateLength = 400u;
+            /*
+             await Task.WhenAll(
+                 UsernameEntry.TranslateTo(0, 0, easing: Easing.SpringOut, length: translateLength),
+                 UsernameEntry.FadeTo(1),
+                 (new Func<Task>(async () =>
+                 {
+                     await Task.Delay(200);
+                     await Task.WhenAll(
+                         PasswordEntry.TranslateTo(0, 0, easing: Easing.SpringOut, length: translateLength),
+                         PasswordEntry.FadeTo(1));
 
-                }))());
-           */
+                 }))());
+            */
             //await Task.WhenAll(
-                //CloseImage.FadeTo(1),
-                //CloseImage.ScaleTo(1, easing: Easing.SpringOut),
-                //CloseImage.RotateTo(0),
-                //LoginButton.ScaleTo(1),
-                //LoginButton.FadeTo(1));
+            //CloseImage.FadeTo(1),
+            //CloseImage.ScaleTo(1, easing: Easing.SpringOut),
+            //CloseImage.RotateTo(0),
+            //LoginButton.ScaleTo(1),
+            //LoginButton.FadeTo(1));
         }
 
         /*

--- a/Rg.Popup.Plugin.Maui/SampleMaui/CSharpMarkup/MainPage.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/CSharpMarkup/MainPage.cs
@@ -1,17 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
-
-using Rg.Plugins.Popup.Pages;
-using Microsoft.Maui.Essentials;
-using AsyncAwaitBestPractices;
-using Rg.Plugins.Popup.Services;
+﻿
 using AsyncAwaitBestPractices.MVVM;
+using Rg.Plugins.Popup.Pages;
+using Rg.Plugins.Popup.Services;
 using Button = Microsoft.Maui.Controls.Button;
 using ScrollView = Microsoft.Maui.Controls.ScrollView;
 
@@ -70,8 +60,8 @@ namespace SampleMaui.CSharpMarkup
                 });
             });
         }
-        
 
-        
+
+
     }
 }

--- a/Rg.Popup.Plugin.Maui/SampleMaui/CSharpMarkup/MainPage.logic.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/CSharpMarkup/MainPage.logic.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Microsoft.Maui.Controls;
+﻿using System.Diagnostics;
 
 using Rg.Plugins.Popup.Services;
 
@@ -24,8 +17,8 @@ namespace SampleMaui.CSharpMarkup
         }
 
         protected override void OnAppearing()
-        { 
-        
+        {
+
         }
     }
 }

--- a/Rg.Popup.Plugin.Maui/SampleMaui/MauiProgram.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/MauiProgram.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.Maui;
-using Microsoft.Maui.Controls.Compatibility;
-using Microsoft.Maui.Controls.Hosting;
-using Microsoft.Maui.Hosting;
-using Microsoft.Maui.LifecycleEvents;
+﻿using Microsoft.Maui.LifecycleEvents;
 using Rg.Plugins.Popup;
 using Rg.Plugins.Popup.Pages;
-using Rg.Plugins.Popup.Services;
 
 namespace SampleMaui
 {
@@ -24,12 +19,10 @@ namespace SampleMaui
                 {
 #if ANDROID
                     lifecycle.AddAndroid(d => d.OnBackPressed(activity => Popup.SendBackPressed(activity.OnBackPressed)));
-                
 #endif
                 })
                 .ConfigureMauiHandlers(handlers =>
                 {
-
                     //handlers.AddMauiControlsHandlers();
                     handlers.AddHandler(typeof(PopupPage), typeof(PopupPageHandler));
                     //handlers.AddCompatibilityRenderer(typeof(PopupPage), typeof(PopupPageHandler));

--- a/Rg.Popup.Plugin.Maui/SampleMaui/Platforms/Android/AndroidManifest.xml
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/Platforms/Android/AndroidManifest.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/Rg.Popup.Plugin.Maui/SampleMaui/Platforms/Android/MainActivity.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/Platforms/Android/MainActivity.cs
@@ -1,6 +1,5 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Microsoft.Maui;
 
 namespace SampleMaui
 {

--- a/Rg.Popup.Plugin.Maui/SampleMaui/Platforms/Android/MainApplication.cs
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/Platforms/Android/MainApplication.cs
@@ -1,13 +1,6 @@
 ﻿using Android.App;
 using Android.Runtime;
 
-using Microsoft.Maui;
-using Microsoft.Maui.Hosting;
-
-using Rg.Plugins.Popup.Services;
-
-using System;
-
 namespace SampleMaui
 {
     [Application]

--- a/Rg.Popup.Plugin.Maui/SampleMaui/SampleMaui.csproj
+++ b/Rg.Popup.Plugin.Maui/SampleMaui/SampleMaui.csproj
@@ -55,7 +55,6 @@
 
 	<ItemGroup>
 	  <PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="6.0.1" />
-	  <PackageReference Include="Xamarin.CommunityToolkit.Markup.MauiCompat" Version="1.3.0-alpha2" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
- Preview 11 added MAUI-specific implicit usings, so removed not needed explicit usings
- Also it seems like referencing NuGets that were built using Preview 10 breaks the build (https://github.com/dotnet/maui/issues/3965), so removed Markup from Sample (it's not used anyway)

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#684

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
