### PR TITLE
Fixed Andriod Screenreader Accessibility (#721)

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
+++ b/Rg.Plugins.Popup/Platforms/Android/Impl/PopupPlatformDroid.cs
@@ -116,17 +116,26 @@ namespace Rg.Plugins.Popup.Droid.Impl
             {
                 if (page.AndroidTalkbackAccessibilityWorkaround)
                 {
-                    var navCount = XApplication.Current.MainPage.Navigation.NavigationStack.Count;
-                    var modalCount = XApplication.Current.MainPage.Navigation.ModalStack.Count;
-                    XApplication.Current.MainPage.GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
+                    var mainPage = XApplication.Current.MainPage;
+
+                    var navCount = mainPage.Navigation.NavigationStack.Count;
+                    var modalCount = mainPage.Navigation.ModalStack.Count;
+
+                    var mainPageRenderer = mainPage.GetOrCreateRenderer();
+
+                    // Workaround for https://github.com/rotorgames/Rg.Plugins.Popup/issues/721
+                    if (!(mainPage is MultiPage<Page>))
+                    {
+                        mainPageRenderer.View.ImportantForAccessibility = ImportantForAccessibility.Auto;
+                    }
 
                     if (navCount > 0)
                     {
-                        XApplication.Current.MainPage.Navigation.NavigationStack[navCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
+                        mainPage.Navigation.NavigationStack[navCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
                     }
                     if (modalCount > 0)
                     {
-                        XApplication.Current.MainPage.Navigation.ModalStack[modalCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
+                        mainPage.Navigation.ModalStack[modalCount - 1].GetOrCreateRenderer().View.ImportantForAccessibility = ImportantForAccessibility.Auto;
                     }
                 }
             }


### PR DESCRIPTION
Implemented a fix for 721 which will no longer unhide invisible views if they are in the view hierarchy for screen readers

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix for #721 

### :arrow_heading_down: What is the current behavior?

See explanation in #721 for description and video, tl;dr:
Android screenreader picks up elements that aren't visible after popup is closed

### :new: What is the new behavior (if this is a feature change)?
Fix popup close accessibility for `TabbedPage` layouts

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
I have rebased by bug report branch with this & you can pull in the changes to demonstrate the fix.

There would need to be a test designed to pick this up in an app, like the repro I provided.

### :memo: Links to relevant issues/docs

#721 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated - NA
- [X] Rebased onto current develop
