### PR TITLE
Only include WPF on .NET Framework project

### DIFF
--- a/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
+++ b/Rg.Plugins.Popup/Rg.Plugins.Popup.csproj
@@ -17,7 +17,7 @@
     <PackageId>Rg.Plugins.Popup</PackageId>
     <Description>Plugin for Xamarin forms. Allows you to open any page as a popup.</Description>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
-    <UseWPF Condition=" '$(OS)' == 'Windows_NT' ">true</UseWPF>
+    <UseWPF Condition=" $(TargetFramework.StartsWith('net4')) And '$(OS)' == 'Windows_NT' ">true</UseWPF>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap')) And '$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
The WPF platform files are included by this condition :
> <span>$</span>(TargetFramework.StartsWith('net4')) And '$(OS)' == 'Windows_NT'
 
but the WPF framework included by the UseWPF property is included by the condition :

> '$(OS)' == 'Windows_NT'

Use the same condition to not include Wpf when not in NET Framework project.

### :arrow_heading_down: What is the current behavior?
When creating a test project targeting net5.0/net6.0 that reference a library that using this library, the build fail because the WPF FrameworkReferences is required, this force to use net5.0-windows or net6.0-windows. The build fail with error NETSDK1136.

### :new: What is the new behavior (if this is a feature change)?
WPF is now only required on .NET Framework project.

### :boom: Does this PR introduce a breaking change?
No because the WPF framework was required but the platform files was not included on non .NET Framework project.

### :bug: Recommendations for testing
Reference the library in a project targeting net5.0/net6.0, the build should not fail with error NETSDK1136.

### :memo: Links to relevant issues/docs
Issue #568

### :thinking: Checklist before submitting
- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop