### PR TITLE
Forward "rotation" methods directly to renderer

### DIFF
--- a/Rg.Plugins.Popup/Platforms/Ios/Platform/PopupPlatformRenderer.cs
+++ b/Rg.Plugins.Popup/Platforms/Ios/Platform/PopupPlatformRenderer.cs
@@ -1,6 +1,7 @@
-﻿
-using Foundation;
+﻿#nullable enable
 
+using System;
+using Foundation;
 using UIKit;
 
 using Xamarin.Forms.Platform.iOS;
@@ -11,13 +12,11 @@ namespace Rg.Plugins.Popup.IOS.Platform
     [Register("RgPopupPlatformRenderer")]
     internal class PopupPlatformRenderer : UIViewController
     {
-        private IVisualElementRenderer? _renderer;
-
-        public IVisualElementRenderer? Renderer => _renderer;
+        public IVisualElementRenderer? Renderer { get; private set; }
 
         public PopupPlatformRenderer(IVisualElementRenderer renderer)
         {
-            _renderer = renderer;
+            Renderer = renderer;
         }
 
         public PopupPlatformRenderer(IntPtr handle) : base(handle)
@@ -29,67 +28,43 @@ namespace Rg.Plugins.Popup.IOS.Platform
         {
             if (disposing)
             {
-                _renderer = null;
+                Renderer = null;
             }
 
             base.Dispose(disposing);
         }
 
         public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].GetSupportedInterfaceOrientations();
-            }
-            return base.GetSupportedInterfaceOrientations();
-        }
+            => Renderer?.ViewController?.GetSupportedInterfaceOrientations() ??
+               base.GetSupportedInterfaceOrientations();
 
         public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
-            }
-            return base.PreferredInterfaceOrientationForPresentation();
-        }
+            => Renderer?.ViewController?.PreferredInterfaceOrientationForPresentation() ??
+               base.PreferredInterfaceOrientationForPresentation();
 
-        public override UIViewController ChildViewControllerForStatusBarHidden()
-        {
-            return _renderer?.ViewController!;
-        }
+        public override UIViewController? ChildViewControllerForStatusBarHidden()
+            => Renderer?.ViewController?.ChildViewControllerForStatusBarHidden() ??
+               base.ChildViewControllerForStatusBarHidden();
 
         public override bool PrefersStatusBarHidden()
-        {
-            return _renderer?.ViewController.PrefersStatusBarHidden() ?? false;
-        }
+            => Renderer?.ViewController?.PrefersStatusBarHidden() ??
+               base.PrefersStatusBarHidden();
 
-        public override UIViewController ChildViewControllerForStatusBarStyle()
-        {
-            return _renderer?.ViewController!;
-        }
+        public override UIViewController? ChildViewControllerForStatusBarStyle()
+            => Renderer?.ViewController ??
+               base.ChildViewControllerForStatusBarStyle();
 
         public override UIStatusBarStyle PreferredStatusBarStyle()
-        {
-            return (UIStatusBarStyle)(_renderer?.ViewController.PreferredStatusBarStyle())!;
-        }
+            => Renderer?.ViewController?.PreferredStatusBarStyle() ??
+               base.PreferredStatusBarStyle();
 
         public override bool ShouldAutorotate()
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].ShouldAutorotate();
-            }
-            return base.ShouldAutorotate();
-        }
+            => Renderer?.ViewController?.ShouldAutorotate() ??
+               base.ShouldAutorotate();
 
         public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
-        {
-            if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-            {
-                return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
-            }
-            return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
-        }
+            => Renderer?.ViewController?.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation) ??
+               base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
 
         public override bool ShouldAutomaticallyForwardRotationMethods => true;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR refactors the iOS `PopupPlatformRendreer` to forward all "rotation" method to the renderer. This is what was already bing done for the `PreferredStatusBarStyle` and `ChildViewControllerForStatusBarHidden` methods. Before `PopupPlatformRendreer` was proxying to the first child view controller. This was ineffective and the renderer is never set as a child view controller.

### :arrow_heading_down: What is the current behavior?

Currently, if the `PopupPageRenderer` is inherited from and the "rotation" methods are overloaded, they are never called and it is impossible to tailer  the supported orientations.

### :new: What is the new behavior (if this is a feature change)?

The new behavior allows the "rotation" methods to be called when overloaded.

### :boom: Does this PR introduce a breaking change?

No breaking charges are know to have been introduced.

### :bug: Recommendations for testing

Register and new renderer that inherits from `PopupPageRenderer` and overload the "rotation" methods. Choose whatever orientation mask you prefer. Run the sample and verify that orientation of the popup matches the mask when the device/simulator is rotated.
